### PR TITLE
Support for comma separated exclude patterns from CLI

### DIFF
--- a/copyfiles
+++ b/copyfiles
@@ -7,7 +7,7 @@ program.version(pkg.version)
   .option('-u, --up [levels]', 'slice a path off the bottom of the paths', parseInt)
   .option('-a --all', 'include files and directories whose names begin with a dot (.)')
   .option('-f, --flat', 'flatten the output')
-  .option('-e, --exclude [pattern]', 'pattern or glob to exclude')
+  .option('-e, --exclude [pattern]', 'pattern or glob to exclude', list)
   .option('-s, --soft', 'do not overwrite destination files if they exist')
   .usage('[options] inFile [more files ...] outDirectory')
   .parse(process.argv);
@@ -22,3 +22,6 @@ copyfiles(program.args, program, function (err) {
     process.exit(0);
   }
 });
+function list(val) {
+  return val.split(',');
+}

--- a/test/test.fromNode.js
+++ b/test/test.fromNode.js
@@ -107,6 +107,36 @@ test('all from cl 2', function (t) {
   });
   t.test('teardown', after);
 });
+test('cl with single exclude', function (t) {
+  t.test('setup', before);
+  t.test('copy stuff', function (t) {
+    fs.writeFileSync('input/a.txt', 'a');
+    fs.writeFileSync('input/b.txt', 'b');
+    fs.writeFileSync('input/c.txt', 'c');
+    cp.spawnSync('./copyfiles', ['-e', 'input/a*', 'input/*.txt', 'output']);
+    fs.readdir('output/input', function (err, files) {
+      t.error(err, 'readdir');
+      t.deepEquals(files, ['b.txt', 'c.txt'], 'correct number of things');
+      t.end();
+    });
+  });
+  t.test('teardown', after);
+});
+test('cl with multiple exclude', function (t) {
+  t.test('setup', before);
+  t.test('copy stuff', function (t) {
+    fs.writeFileSync('input/a.txt', 'a');
+    fs.writeFileSync('input/b.txt', 'b');
+    fs.writeFileSync('input/c.txt', 'c');
+    cp.spawnSync('./copyfiles', ['-e', 'input/a*,input/b*', 'input/*.txt', 'output']);
+    fs.readdir('output/input', function (err, files) {
+      t.error(err, 'readdir');
+      t.deepEquals(files, ['c.txt'], 'correct number of things');
+      t.end();
+    });
+  });
+  t.test('teardown', after);
+});
 test('soft', function (t) {
   t.test('setup', before);
   t.test('copy stuff', function (t) {


### PR DESCRIPTION
Added simple changes to support multiple exclude patterns (comma separated) in the CLI -e parameter.

(BTW, your tests don't succeed on Windows - had to run them on Linux to confirm)