### PR TITLE
fix(stream): proper error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,7 @@ function copyFiles(args, config, callback) {
       next();
     });
   }))
+  .on('error', callback)
   .pipe(through(function (pathName, _, next) {
     fs.stat(pathName, function (err, pathStat) {
       if (err) {
@@ -108,6 +109,7 @@ function copyFiles(args, config, callback) {
       })
     });
   }))
+  .on('error', callback)
   .pipe(through(function (pathName, _, next) {
     var outName = path.join(outDir, dealWith(pathName, opts));
     fs.createReadStream(pathName)


### PR DESCRIPTION
if mkdirp raises an error, e.g trying to create a folder inside a read-only target, the error does not get propagated properly to the consumer and the client app dies without any chance to catch it.

Added it for the first glob pipe as well, although not sure how this might be possible to fail (tried by throwing error manually from within code)