### PR TITLE
Update yargs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "mkdirp": "^0.5.1",
     "noms": "0.0.0",
     "through2": "^2.0.1",
-    "yargs": "^11.0.0"
+    "yargs": "^13.2.4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Currently, `yargs@11` has a dependency on `os-locale@2`, which has a dependency on `mem@1`, which has a security vulnerability as detailed [here](https://bugzilla.redhat.com/show_bug.cgi?id=1623744).

Here, we upgrade to `yargs@13` so that users of `copyfiles` get `mem@4` instead of `mem@1`.