### PR TITLE
Pass the array of files copied to the callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,13 +154,14 @@ function copyFiles(args, config, callback) {
     var outName = path.join(outDir, dealWith(pathName, opts));
     debug(`copy from: ${pathName}`)
     debug(`copy to: ${outName}`)
+    var cwd = process.cwd();
     copyFile(pathName, outName, pathStat, function(err) {
       if (err) {
         return next(err);
       }
       results.push({
-        from: path.resolve(process.cwd(), pathName),
-        to: path.resolve(process.cwd(), outName),
+        from: path.resolve(cwd, pathName),
+        to: path.resolve(cwd, outName),
       });
       next();
     })

--- a/readme.md
+++ b/readme.md
@@ -100,4 +100,15 @@ var copyfiles = require('copyfiles');
 
 copyfiles([paths], opt, callback);
 ```
-takes an array of paths, last one is the destination path, also takes an optional argument which the -u option if a number, otherwise if it's `true` it's the flat option or if it is an object it is a hash of the various options (the long version e.g. up, all, flat, exclude, error, verbose and soft)  
+
+Takes an array of paths, last one is the destination path, also takes an optional argument which the -u option if a number, otherwise if it's `true` it's the flat option or if it is an object it is a hash of the various options (the long version e.g. up, all, flat, exclude, error, verbose and soft).
+
+The callback is a typical Node.js-style error-first callback, where the second argument is an array containing information about where files have been copied from and to.
+
+```js
+copyfiles(['./src/**/*.json', './dist'], { up: 1 }, (err, files) => {
+  if (!err) {
+    console.log(files); // [ { from: '/app/src/foo.json', to: '/app/dist/foo.json' } ]
+  }
+});
+```


### PR DESCRIPTION
In my app I needed to know the files that `copyfiles` actually copied.

This PR makes the programatic API callback receive an array of objects containing each `from` and `to` path of the files that were copied.

Example (ripped from the README):

```js
copyfiles(['./src/**/*.json', './dist'], { up: 1 }, (err, files) => {
  if (!err) {
    console.log(files); // [ { from: '/app/src/foo.json', to: '/app/dist/foo.json' } ]
  }
});
```

Not sure if this is a feature you also feel should be added into the library. If it's not, I'll just resort to using a forked/patched version of it, because it adds a convenience I feel is super beneficial.