### PR TITLE
Fixed broken command and corrupt help output.

### DIFF
--- a/copyfiles
+++ b/copyfiles
@@ -6,8 +6,10 @@ var path = require('path');
 args.alias('u', 'up')
   .describe('u', 'slice a path off the bottom of the paths')
   .number('u')
-if (path.basename(args.argv.$0) === 'copyup') {
-  args.default('u', '1');
+// `args.argv` cannot be parsed twice
+// so we use the builtin `process.argv`
+if (path.basename(process.argv.slice(1, 2)[0]) === 'copyup') {
+  args.default('u', 1);
 }
 args.alias('a', 'all')
   .describe('a', 'include files & directories begining with a dot (.)')


### PR DESCRIPTION
Fixes #241.

`copyfiles` parses `args.argv` multiple times in an attempt to set the correct default value for option `u`.
However, this crashes the command and corrupts the help output screen.

To workaround that, this PR uses the builtin `process.argv` array to get at the command file name.