### PR TITLE
feat: add { flat: true } opt in the programmatic API

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ function copyFiles(args, config, callback) {
   }
   var debug = makeDebug(config);
   var copied = false;
-  var opts = config.up || 0;
+  var opts = config.flat || config.up || 0;
   var soft = config.soft;
   if (typeof callback !== 'function') {
     throw new Error('callback is not optional');


### PR DESCRIPTION
Solves issue #86.
`{ flat: true }` is an alias of `{ up: true }`.

Before this change you had to call:
`copyfiles( [source, output], { up: true }, callback )`

Now the programmatic API mirrors the CLI and it is also possibile to call:
`copyfiles( [source, output], { flat: true }, callback )`